### PR TITLE
only query pcache indexes

### DIFF
--- a/check_pcache_hit-miss-ratio.py
+++ b/check_pcache_hit-miss-ratio.py
@@ -177,7 +177,7 @@ def main():
 
     baseurl = "http://" + options.servername + ":" + str(options.port) + "/"
 
-    url = baseurl + "_all/pcache/_search?pretty"
+    url = baseurl + "pcache-*/pcache/_search?pretty"
     query = build_query(options.volumekey, options.time)
     res = fetch(url, query)
 


### PR DESCRIPTION
ElasticSearch now consists of a few more indexes than a couple of years ago. This caused "_all" indexes to be to large (> 1000). Limiting to only query pcache-* indexes solves the issue and improves performance.